### PR TITLE
Reenable AltiVec support and fix test failures on ppc64el

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,6 +447,17 @@ set(FFTS_SOURCES
   src/types.h
 )
 
+if(NOT DISABLE_DYNAMIC_CODE)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
+    list(APPEND FFTS_SOURCES
+      src/codegen_sse.h
+    )
+  else()
+    message(WARNING "Dynamic code is only supported with x64, disabling dynamic code.")
+    set(DISABLE_DYNAMIC_CODE ON)
+  endif(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
+endif(NOT DISABLE_DYNAMIC_CODE)
+
 if(ENABLE_NEON)
   list(APPEND FFTS_SOURCES
     src/neon.s
@@ -474,17 +485,6 @@ elseif(HAVE_XMMINTRIN_H)
     src/macros-avx.h
     src/macros-sse.h
   )
-
-  if(NOT DISABLE_DYNAMIC_CODE)
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-      list(APPEND FFTS_SOURCES
-        src/codegen_sse.h
-      )
-    else()
-      message(WARNING "Dynamic code is only supported with x64, disabling dynamic code.")
-      set(DISABLE_DYNAMIC_CODE ON)
-    endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-  endif(NOT DISABLE_DYNAMIC_CODE)
 endif(ENABLE_NEON)
 
 if(DISABLE_DYNAMIC_CODE)

--- a/src/macros.h
+++ b/src/macros.h
@@ -48,8 +48,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "macros-sse.h"
 #endif
 // NOTE: AltiVec support disabled until updated to provide new V4SF variable type
-//#elif __powerpc__
-//#include "macros-altivec.h"
+#elif __powerpc__
+#include "macros-altivec.h"
 #else
 #include "macros-alpha.h"
 #endif


### PR DESCRIPTION
Tested on Talos II

```
./ffts_trig_test
Verify single precision trig table using FNV-1a checksum:
536870912: ok
268435456: ok
134217728: ok
 67108864: ok
 33554432: ok
 16777216: ok
  8388608: ok
  4194304: ok
  2097152: ok
  1048576: ok
   524288: ok
   262144: ok
   131072: ok
    65536: ok
    32768: ok
    16384: ok
     8192: ok
     4096: ok
     2048: ok
     1024: ok
      512: ok
      256: ok
      128: ok
       64: ok
       32: ok
       16: ok
        8: ok
        4: ok
        2: ok
        1: ok
Verify double precision trig table using FNV-1a checksum:
536870912: ok
268435456: ok
134217728: ok
 67108864: ok
 33554432: ok
 16777216: ok
  8388608: ok
  4194304: ok
  2097152: ok
  1048576: ok
   524288: ok
   262144: ok
   131072: ok
    65536: ok
    32768: ok
    16384: ok
     8192: ok
     4096: ok
     2048: ok
     1024: ok
      512: ok
      256: ok
      128: ok
       64: ok
       32: ok
       16: ok
        8: ok
        4: ok
        2: ok
        1: ok
```

```
 Sign |      Size |     L2 Error
------+-----------+-------------
  -1  |         2 | 8.659561E-17
  -1  |         4 | 1.145552E-16
  -1  |         8 | 1.210162E-08
  -1  |        16 | 2.220916E-08
  -1  |        32 | 1.322876E+00
  -1  |        64 | 1.369306E+00
  -1  |       128 | 1.391941E+00
  -1  |       256 | 1.403121E+00
  -1  |       512 | 1.408678E+00
  -1  |      1024 | 1.411449E+00
  -1  |      2048 | 1.412832E+00
  -1  |      4096 | 1.413523E+00
  -1  |      8192 | 1.413868E+00
  -1  |     16384 | 1.414041E+00
  -1  |     32768 | 1.414127E+00
  -1  |     65536 | 1.414170E+00
  -1  |    131072 | 1.414192E+00
  -1  |    262144 | 1.414203E+00
   1  |         2 | 8.659561E-17
   1  |         4 | 1.145552E-16
   1  |         8 | 1.210162E-08
   1  |        16 | 2.220916E-08
   1  |        32 | 1.322876E+00
   1  |        64 | 1.369306E+00
   1  |       128 | 1.391941E+00
   1  |       256 | 1.403121E+00
   1  |       512 | 1.408678E+00
   1  |      1024 | 1.411449E+00
   1  |      2048 | 1.412832E+00
   1  |      4096 | 1.413523E+00
   1  |      8192 | 1.413868E+00
   1  |     16384 | 1.414041E+00
   1  |     32768 | 1.414127E+00
   1  |     65536 | 1.414170E+00
   1  |    131072 | 1.414192E+00
   1  |    262144 | 1.414203E+00
```